### PR TITLE
Fix org loading to not include org languages

### DIFF
--- a/archiver.go
+++ b/archiver.go
@@ -53,7 +53,6 @@ type Org struct {
 	Name            string    `db:"name"`
 	CreatedOn       time.Time `db:"created_on"`
 	IsAnon          bool      `db:"is_anon"`
-	Language        *string   `db:"language"`
 	RetentionPeriod int
 }
 
@@ -98,9 +97,8 @@ func (a *Archive) coversDate(d time.Time) bool {
 }
 
 const lookupActiveOrgs = `
-SELECT o.id, o.name, l.iso_code as language, o.created_on, o.is_anon 
+SELECT o.id, o.name, o.created_on, o.is_anon 
 FROM orgs_org o 
-LEFT JOIN orgs_language l ON l.id = primary_language_id 
 WHERE o.is_active = TRUE order by o.id
 `
 

--- a/testdb.sql
+++ b/testdb.sql
@@ -1,16 +1,9 @@
 CREATE EXTENSION IF NOT EXISTS HSTORE;
 
-DROP TABLE IF EXISTS orgs_language CASCADE;
-CREATE TABLE orgs_language (
-    id serial primary key,
-    iso_code character varying(3)
-);
-
 DROP TABLE IF EXISTS orgs_org CASCADE;
 CREATE TABLE orgs_org (
     id serial primary key,
     name character varying(255) NOT NULL,
-    primary_language_id integer references orgs_language(id) on delete cascade,
     is_anon boolean NOT NULL,
     is_active boolean NOT NULL,
     created_on timestamp with time zone NOT NULL
@@ -219,14 +212,11 @@ CREATE TABLE flows_flowpathrecentrun (
     run_id integer NOT NULL references flows_flowrun(id) DEFERRABLE INITIALLY DEFERRED
 );
 
-INSERT INTO orgs_language(id, iso_code) VALUES 
-(1, 'eng');
-
-INSERT INTO orgs_org(id, name, is_active, is_anon, created_on, primary_language_id) VALUES
-(1, 'Org 1', TRUE, FALSE, '2017-11-10 21:11:59.890662+00', 1),
-(2, 'Org 2', TRUE, FALSE, '2017-08-10 21:11:59.890662+00', 1),
-(3, 'Org 3', TRUE, TRUE, '2017-08-10 21:11:59.890662+00', NULL),
-(4, 'Org 4', FALSE, TRUE, '2017-08-10 21:11:59.890662+00', 1);
+INSERT INTO orgs_org(id, name, is_active, is_anon, created_on) VALUES
+(1, 'Org 1', TRUE, FALSE, '2017-11-10 21:11:59.890662+00'),
+(2, 'Org 2', TRUE, FALSE, '2017-08-10 21:11:59.890662+00'),
+(3, 'Org 3', TRUE, TRUE, '2017-08-10 21:11:59.890662+00'),
+(4, 'Org 4', FALSE, TRUE, '2017-08-10 21:11:59.890662+00');
 
 INSERT INTO channels_channel(id, uuid, name, org_id) VALUES
 (1, '8c1223c3-bd43-466b-81f1-e7266a9f4465', 'Channel 1', 1),


### PR DESCRIPTION
Archiver doesn't appear to use languages so is just blowing up because it's trying to join on a table that no longer exists.