### PR TITLE
Change query used to update `rollup_id` on dailies and remove temporary logging

### DIFF
--- a/archives/archives_test.go
+++ b/archives/archives_test.go
@@ -534,7 +534,7 @@ func TestArchiveActiveOrgs(t *testing.T) {
 		assert.NoError(t, err)
 
 		assert.Equal(t, map[string][]float64{
-			"archiver.archive_elapsed":       {860.0},
+			"archiver.archive_elapsed":       {848.0},
 			"archiver.orgs_archived":         {3},
 			"archiver.msgs_records_archived": {5},
 			"archiver.msgs_archives_created": {92},


### PR DESCRIPTION
```sql
explain analyze 
select id from archives_archive 
where ARRAY[id] <@ ARRAY[54118149, 54118148, 56333439, 56290435, 56247442, 56204463, 56161496, 56118503, 56075555, 56032618, 55989709, 55946808, 55903926, 55861064, 55818208, 55775283, 55732446, 55689626, 55462093, 55462092, 55462091, 55462090, 55462089, 55462088, 55462087, 55462086, 55462085, 55462084, 55462083, 55462082, 55462081];
```

```
 Gather  (cost=1000.00..1930203.70 rows=249648 width=4) (actual time=5533.735..6829.038 rows=31 loops=1)
   Workers Planned: 2
   Workers Launched: 2
   ->  Parallel Seq Scan on archives_archive  (cost=0.00..1904238.90 rows=104020 width=4) (actual time=5635.634..6823.444 rows=10 loops=3)
         Filter: (ARRAY[id] <@ '{54118149,54118148,56333439,56290435,56247442,56204463,56161496,56118503,56075555,56032618,55989709,55946808,55903926,55861064,55818208,55775283,55732446,55689626,55462093,55462092,55462091,55462090,55462089,55462088,55462087,55462086,55462085,55462084,55462083,55462082,55462081}'::integer[])
         Rows Removed by Filter: 16649328
 Planning Time: 0.055 ms
 Execution Time: 6829.059 ms
```

vs

```sql
explain analyze 
select id from archives_archive 
where id = ANY(ARRAY[54118149, 54118148, 56333439, 56290435, 56247442, 56204463, 56161496, 56118503, 56075555, 56032618, 55989709, 55946808, 55903926, 55861064, 55818208, 55775283, 55732446, 55689626, 55462093, 55462092, 55462091, 55462090, 55462089, 55462088, 55462087, 55462086, 55462085, 55462084, 55462083, 55462082, 55462081]);
```

```
 Index Only Scan using archives_archive_pkey on archives_archive  (cost=0.56..149.14 rows=31 width=4) (actual time=0.031..0.168 rows=31 loops=1)
   Index Cond: (id = ANY ('{54118149,54118148,56333439,56290435,56247442,56204463,56161496,56118503,56075555,56032618,55989709,55946808,55903926,55861064,55818208,55775283,55732446,55689626,55462093,55462092,55462091,55462090,55462089,55462088,55462087,55462086,55462085,55462084,55462083,55462082,55462081}'::integer[]))
   Heap Fetches: 62
 Planning Time: 0.071 ms
 Execution Time: 0.177 ms
```