### PR TITLE
Add -ignore-md5-sum flag

### DIFF
--- a/archives/config.go
+++ b/archives/config.go
@@ -17,9 +17,10 @@ type Config struct {
 	AWSAccessKeyID     string `help:"the access key id to use when authenticating S3"`
 	AWSSecretAccessKey string `help:"the secret access key id to use when authenticating S3"`
 
-	TempDir    string `help:"directory where temporary archive files are written"`
-	KeepFiles  bool   `help:"whether we should keep local archive files after upload (default false)"`
-	UploadToS3 bool   `help:"whether we should upload archive to S3"`
+	TempDir      string `help:"directory where temporary archive files are written"`
+	KeepFiles    bool   `help:"whether we should keep local archive files after upload (default false)"`
+	UploadToS3   bool   `help:"whether we should upload archive to S3"`
+	IgnoreMD5Sum bool   `help:"whether to ignore md5sum S3 ETag comparison before deleting"`
 
 	ArchiveMessages bool   `help:"whether we should archive messages"`
 	ArchiveRuns     bool   `help:"whether we should archive runs"`

--- a/archives/messages.go
+++ b/archives/messages.go
@@ -131,7 +131,7 @@ func DeleteArchivedMessages(ctx context.Context, config *Config, db *sqlx.DB, s3
 	}
 
 	// if our etag and archive md5 don't match, that's an error, return
-	if md5 != archive.Hash {
+	if !config.IgnoreMD5Sum && md5 != archive.Hash {
 		return fmt.Errorf("archive md5: %s and s3 etag: %s do not match", archive.Hash, md5)
 	}
 

--- a/archives/runs.go
+++ b/archives/runs.go
@@ -131,7 +131,7 @@ func DeleteArchivedRuns(ctx context.Context, config *Config, db *sqlx.DB, s3Clie
 	}
 
 	// if our etag and archive md5 don't match, that's an error, return
-	if md5 != archive.Hash {
+	if !config.IgnoreMD5Sum && md5 != archive.Hash {
 		return fmt.Errorf("archive md5: %s and s3 etag: %s do not match", archive.Hash, md5)
 	}
 


### PR DESCRIPTION
Per #87, S3 often generates ETag differently from pure MD5 hash which means that database entries are not cleared.